### PR TITLE
added MakeSchemaConfig method

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -16,6 +16,7 @@ type registry struct {
 	types            map[string]graphql.Type
 	directives       map[string]*graphql.Directive
 	schema           *graphql.Schema
+	schemaConfig     *graphql.SchemaConfig
 	resolverMap      ResolverMap
 	directiveMap     SchemaDirectiveVisitorMap
 	schemaDirectives []*ast.Directive

--- a/schema.go
+++ b/schema.go
@@ -27,7 +27,7 @@ type ExecutableSchema struct {
 	Extensions       []graphql.Extension       // GraphQL extensions
 }
 
-// MakeSchemaConfig creates a graphql schema config, which contains all the types parsed from the typeDefs
+// MakeSchemaConfig creates a graphql schema config, this struct maintains intact the types and does not require the use of a non empty Query
 func (c *ExecutableSchema) MakeSchemaConfig() (graphql.SchemaConfig, error) {
 	// combine the TypeDefs
 	document, err := c.ConcatenateTypeDefs()

--- a/schema.go
+++ b/schema.go
@@ -17,6 +17,11 @@ func MakeExecutableSchema(config ExecutableSchema) (graphql.Schema, error) {
 	return config.Make()
 }
 
+// MakeSchemaConfig creates a schema config that maintain intact types
+func MakeSchemaConfig(config ExecutableSchema) (graphql.SchemaConfig, error) {
+	return config.MakeSchemaConfig()
+}
+
 // ExecutableSchema configuration for making an executable schema
 // this attempts to provide similar functionality to Apollo graphql-tools
 // https://www.apollographql.com/docs/graphql-tools/generate-schema

--- a/schema_test.go
+++ b/schema_test.go
@@ -114,7 +114,7 @@ schema {
 	}
 }
 
-func TestMakeConfigSchema(t *testing.T) {
+func TestMakeSchemaConfig(t *testing.T) {
 	typeDefs := `
 type Foo {
 	name: String!

--- a/schema_test.go
+++ b/schema_test.go
@@ -113,3 +113,36 @@ schema {
 		return
 	}
 }
+
+func TestMakeConfigSchema(t *testing.T) {
+	typeDefs := `
+type Foo {
+	name: String!
+	description: String
+}
+`
+	// make the schema
+	config := ExecutableSchema{
+		TypeDefs: typeDefs,
+	}
+	schemaConfig, err := config.MakeSchemaConfig()
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	objects := 0
+	for _, gqlType := range schemaConfig.Types {
+		_, err := gqlType.(*graphql.Object)
+		if !err {
+			continue
+		}
+		objects++
+		// for k, field := range obj.Fields() {
+		// 	println(k, field.Type.Name())
+		// }
+	}
+	if objects != 1 {
+		t.Error("MakeSchemaConfig does not maintain schema types")
+	}
+}


### PR DESCRIPTION
With the current implementation the types not used inside Query or Mutation are discarded by `graphql-go` because `graphql.NewSchema` removes them.

I added a `MakeSchemaConfig` method to `ExecutableSchema`, this struct maintains intact the types and does not require the use of a non empty Query
